### PR TITLE
Make sure interpreter is always pre-pended on Windows.

### DIFF
--- a/gst/build_mkenum.py
+++ b/gst/build_mkenum.py
@@ -37,8 +37,14 @@ argn = 1
 for arg in sys.argv[1:]:
     cmd.append(arg)
     argn += 1
-    if arg.endswith('glib-mkenums'):
+    arg = arg.lower()
+    if arg.endswith('glib-mkenums.pl') or arg.endswith('glib-mkenums'):
         break
+
+# In Windows make sure to run through interpreter because there is no shebang
+if sys.platform.startswith('win') and argn == 2:
+    cmd = ['perl'] + cmd
+
 ofilename = sys.argv[argn]
 headers = sys.argv[argn + 1:]
 


### PR DESCRIPTION
Make sure perl is used on Windows, also fix if script has extension.
There are few other places (like in gst-plugins-base) that need a similar fix, but wanted to see if GitHub is the right place.
I am building 1.10 [here](https://github.com/dashesy/cerbero/tree/meson-1.10) linking against glib [here](https://github.com/centricular/glib) because it is meson-based and I want the pdbs.