### PR TITLE
Fix for memory leak

### DIFF
--- a/tools/gst-inspect.c
+++ b/tools/gst-inspect.c
@@ -573,7 +573,9 @@ print_pad_templates_info (GstElement * element, GstElementFactory * factory)
 
     if (padtemplate->static_caps.string) {
       n_print ("    Capabilities:\n");
-      print_caps (gst_static_caps_get (&padtemplate->static_caps), "      ");
+      GstCaps *temp;
+      print_caps ((temp = gst_static_caps_get (&padtemplate->static_caps)), "      ");
+      gst_caps_unref(temp);
     }
 
     n_print ("\n");


### PR DESCRIPTION
Unref GstCaps returned by gst_static_caps_get() to avoid memory leak