### PR TITLE
 Reset gst_initialized flag in gst_deinit()

### DIFF
--- a/gst/gst.c
+++ b/gst/gst.c
@@ -1228,6 +1228,7 @@ gst_deinit (void)
   g_type_class_unref (g_type_class_peek (gst_promise_result_get_type ()));
 
   gst_deinitialized = TRUE;
+  gst_initialized = FALSE;
   GST_INFO ("deinitialized GStreamer");
 }
 


### PR DESCRIPTION
For completeness reset static **gst_initialized** flag to **FALSE** if _gst_deinit()_ is done.