### PR TITLE
Unref pool buffer to avoid potential memory leakage

### DIFF
--- a/subprojects/gst-plugins-good/sys/v4l2/gstv4l2transform.c
+++ b/subprojects/gst-plugins-good/sys/v4l2/gstv4l2transform.c
@@ -907,6 +907,9 @@ gst_v4l2_transform_prepare_output_buffer (GstBaseTransform * trans,
         self->v4l2output->mode == GST_V4L2_IO_DMABUF_IMPORT) {
       if (!gst_v4l2_object_try_import (self->v4l2output, inbuf)) {
         GST_ERROR_OBJECT (self, "cannot import buffers from upstream");
+        if (pool)
+            g_object_unref (pool);
+
         return GST_FLOW_ERROR;
       }
 

--- a/subprojects/gst-plugins-good/sys/v4l2/gstv4l2videoenc.c
+++ b/subprojects/gst-plugins-good/sys/v4l2/gstv4l2videoenc.c
@@ -790,9 +790,9 @@ gst_v4l2_video_enc_handle_frame (GstVideoEncoder * encoder,
           gst_object_unref (pool);
         goto activate_failed;
       }
-      if (pool)
-        gst_object_unref (pool);
     }
+    if (pool)
+        gst_object_unref (pool);
 
     {
       GstBufferPool *cpool =


### PR DESCRIPTION
It is related to this issue: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/3097#note_2156852