### PR TITLE
build: add a simple build script for x86-linux(ubuntu)

### DIFF
--- a/build-x86-linux.sh
+++ b/build-x86-linux.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 export PROJECT_ROOT_PATH=`pwd`
+#export PROJECT_BUILD_TYPE=debug
+export PROJECT_BUILD_TYPE=release
 
 function build_init()
 {


### PR DESCRIPTION

a simple but useful build script for x86-linux(validated ok on Ubuntu 20.04)

![Screenshot from 2024-03-28 20-25-29](https://github.com/GStreamer/gstreamer/assets/6889919/d1e0e8b4-e6e7-4d76-a4e9-a4c8d9d6fcfd)
